### PR TITLE
Use encoded payer key to fund account if available

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -85,6 +85,15 @@
         "@types/node": "*"
       }
     },
+    "@types/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==",
+      "dev": true,
+      "requires": {
+        "base-x": "^3.0.6"
+      }
+    },
     "@types/connect": {
       "version": "3.4.33",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -21,11 +21,13 @@
   },
   "dependencies": {
     "@solana/web3.js": "^0.36.0",
+    "bs58": "^4.0.1",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "ws": "^7.2.1"
   },
   "devDependencies": {
+    "@types/bs58": "^4.0.1",
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.2",
     "@types/node": "^12.7.0",

--- a/server/src/faucet.ts
+++ b/server/src/faucet.ts
@@ -1,0 +1,66 @@
+import {
+  Account,
+  Connection,
+  PublicKey,
+  SystemProgram,
+  sendAndConfirmTransaction,
+  FeeCalculator
+} from "@solana/web3.js";
+import bs58 from "bs58";
+
+const ENCODED_PAYER_KEY = process.env.ENCODED_PAYER_KEY;
+
+export default class Faucet {
+  private payerAccount?: Account;
+  private checkBalanceCounter = 0;
+
+  constructor(
+    private connection: Connection,
+    private feeCalculator: FeeCalculator
+  ) {
+    if (ENCODED_PAYER_KEY) {
+      console.log("Airdrops disabled");
+      this.payerAccount = new Account(bs58.decode(ENCODED_PAYER_KEY));
+      this.checkBalance();
+    }
+  }
+
+  async checkBalance(): Promise<void> {
+    this.checkBalanceCounter++;
+    if (this.checkBalanceCounter % 10 != 1) {
+      return;
+    }
+
+    if (this.payerAccount) {
+      try {
+        const balance = await this.connection.getBalance(
+          this.payerAccount.publicKey
+        );
+        console.log(`Faucet balance: ${balance}`);
+      } catch (err) {
+        console.error("failed to check faucet balance", err);
+      }
+    }
+  }
+
+  async fundAccount(
+    accountPubkey: PublicKey,
+    fundAmount: number
+  ): Promise<void> {
+    if (this.payerAccount) {
+      const creationFee = this.feeCalculator.lamportsPerSignature;
+      await sendAndConfirmTransaction(
+        this.connection,
+        SystemProgram.transfer({
+          fromPubkey: this.payerAccount.publicKey,
+          toPubkey: accountPubkey,
+          lamports: fundAmount + creationFee
+        }),
+        this.payerAccount
+      );
+      this.checkBalance();
+    } else {
+      await this.connection.requestAirdrop(accountPubkey, fundAmount);
+    }
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/break/issues/90

#### Problem
Want to run break on a testnet which doesn't have airdrops enabled

#### Changes
Check `ENCODED_PAYER_KEY` env var and if set, use it to fund accounts rather than airdropping.