### PR TITLE
Fix reconnection bugs

### DIFF
--- a/client/src/services/solana.ts
+++ b/client/src/services/solana.ts
@@ -116,6 +116,7 @@ export class SolanaService {
       }
       this._connection = undefined;
     }
+    this._programId = undefined;
   };
 
   private onPayerAccount = async (accountInfo: AccountInfo) => {

--- a/client/src/services/transaction.ts
+++ b/client/src/services/transaction.ts
@@ -122,11 +122,12 @@ export class TransactionService {
 
   public reconnect = () => {
     if (this.reconnecting) return;
+    this.reconnecting = true;
     this._reconnectLoop();
   };
 
   private _reconnectLoop = async () => {
-    while (this.onConnect) {
+    while (!this.disconnected()) {
       try {
         console.log("Connecting...");
         await this._reconnect();
@@ -138,7 +139,6 @@ export class TransactionService {
         await sleep(1000);
       }
     }
-    this.reconnecting = false;
   };
 
   private _reconnect = async () => {

--- a/client/src/services/websocket.ts
+++ b/client/src/services/websocket.ts
@@ -22,18 +22,27 @@ export class WebSocketService {
         throw new Error("WebSocket open timed out");
       }
       this.socket = socket;
+      this.socket.onclose = () => {
+        this.close();
+      };
+      this.socket.onerror = err => {
+        this.error(err);
+      };
     } finally {
       this.connecting = false;
     }
   };
 
+  error = (err: any) => {
+    console.error(err);
+    this.close();
+  };
+
   send = (data: Buffer) => {
-    if (this.socket) {
-      if (this.socket.readyState == WebSocket.OPEN) {
-        this.socket.send(data);
-      } else {
-        throw new Error("Websocket disconnected");
-      }
+    if (this.socket && this.socket.readyState == WebSocket.OPEN) {
+      this.socket.send(data);
+    } else {
+      throw new Error("Websocket disconnected");
     }
   };
 


### PR DESCRIPTION
There were a few issues:

1. When disconnecting, we were unsubscribing from program account updates but failed to clear the current program id. So, on reconnect, we wouldn't subscribe to program account updates because the program id appeared to be unchanged

2. It was possible to send a "connected" callback twice to the game, which could cause duplicate key listeners.. causing multiple transactions to be sent for each click

3. Websocket was not subscribing to error or close events which help detect a failed connection earlier

4. Websocket service didn't throw an error when sending transactions on a closed connection