### PR TITLE
Fetch blockhash more often to avoid invalid blockhashes

### DIFF
--- a/client/src/providers/blockhash.tsx
+++ b/client/src/providers/blockhash.tsx
@@ -3,7 +3,7 @@ import { Blockhash, Connection } from "@solana/web3.js";
 import { useConfig } from "./api";
 import { sleep } from "utils";
 
-const POLL_INTERVAL_MS = 60000;
+const POLL_INTERVAL_MS = 20000;
 
 export enum ActionType {
   Start,


### PR DESCRIPTION
#### Problem
The blockhash refresh interval is too long and can result in break transactions using a blockhash that's too old.
