### PR TITLE
Fix account request retry bug

### DIFF
--- a/client/src/providers/api/index.tsx
+++ b/client/src/providers/api/index.tsx
@@ -193,7 +193,6 @@ async function refreshAccounts(dispatch: Dispatch, paymentRequired: boolean) {
       refreshed = true;
     } catch (err) {
       console.error("Failed to refresh fee accounts", err);
-      dispatch({ status: ConfigStatus.Failure });
       await sleep(2000);
     }
   }


### PR DESCRIPTION
The fetch state should not change during retryable errors. If set to failure, the UI will prompt the user to retry which starts another retry loop in parallel