### PR TITLE
Fix program loaded check in server

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -41,9 +41,9 @@
       }
     },
     "@solana/web3.js": {
-      "version": "0.66.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.66.0.tgz",
-      "integrity": "sha512-Uw7ooRWLqrq8I5U21mEryvvF/Eqqh4mq4K2W9Sxuz3boxkz7Ed7aAJVj5C5n1fbQr9I1cxxxgC+D5BHnogfS1A==",
+      "version": "0.66.3",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.66.3.tgz",
+      "integrity": "sha512-HYM1z9E6qVZKEHoLAn5tvL4SioruNB/mvNQhW2v7Va1WbhFArMIEh24SPC23LuEFZVe3PKwlT47zzUhdyua8tQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "bn.js": "^5.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
-    "@solana/web3.js": "^0.66.0",
+    "@solana/web3.js": "^0.66.3",
     "@types/cors": "^2.8.7",
     "@types/express": "^4.17.2",
     "@types/node": "^14.0.27",

--- a/server/src/program.ts
+++ b/server/src/program.ts
@@ -35,7 +35,9 @@ export default class ProgramLoader {
     while (true) {
       try {
         // If the program account already exists, don't try to load it again
-        const info = await connection.getAccountInfo(programAccount.publicKey);
+        const info = (
+          await connection.getParsedAccountInfo(programAccount.publicKey)
+        ).value;
         if (info?.executable) return programAccount.publicKey;
 
         const NUM_RETRIES = 100; /* allow some number of retries */


### PR DESCRIPTION
#### Problem
When starting up, Break checks if the program is already loaded by calling `getAccountInfo` to check the executable bit. This call will fail with the recent RPC changes to restrict returning large bs58 strings.

#### Changes
- Update web3
- Use `getParsedAccountInfo` because it falls back to base68