### PR TITLE
Fix bug that reset timing info while in debug mode

### DIFF
--- a/client/src/providers/transactions/index.tsx
+++ b/client/src/providers/transactions/index.tsx
@@ -215,7 +215,26 @@ function reducer(state: State, action: Action): State {
                 [action.commitment]: timeElapsed(tx.timing.sentAt),
               },
             };
-          } else if (tx.pending && !ids.has(id)) {
+          } else if (
+            action.commitment === "recent" &&
+            tx.pending &&
+            !ids.has(id)
+          ) {
+            // Don't revert to pending state if we already received timing info for other commitments
+            if (
+              tx.timing["single"] !== undefined ||
+              tx.timing["singleGossip"] !== undefined
+            ) {
+              return {
+                ...tx,
+                timing: {
+                  ...tx.timing,
+                  recent: undefined,
+                },
+              };
+            }
+
+            // Revert to pending state because the previous notification likely came from a fork
             return {
               status: "pending",
               details: tx.details,


### PR DESCRIPTION
#### Problem
Break attempts to detect when it receives "recent" notifications for a fork. So it will reset timing info when it receives a notification that does not contain a transaction id that it has seen before. This logic did not take into account that notifications for other slower commitment levels may not contain a transaction id yet.

#### Changes
- Only reset timing info for a transaction when a "recent" notification without that transaction id is received and we have not yet received confirmations from "single" or "singleGossip".