### PR TITLE
Send fewer requests to avoid rate limiting

### DIFF
--- a/server/src/supply/accounts.ts
+++ b/server/src/supply/accounts.ts
@@ -4,7 +4,7 @@ import { promisify } from "util";
 import Redis from "redis";
 
 const SUPPLY_SIZE = 50;
-const BATCH_SIZE = 4;
+const BATCH_SIZE = parseInt(process.env.CREATE_ACCOUNT_BATCH_SIZE || "") || 10;
 
 export const TX_PER_ACCOUNT =
   parseInt(process.env.TX_PER_ACCOUNT || "") || 1000;
@@ -108,7 +108,9 @@ export default class AccountSupply {
 
       size = await this.size();
       console.log(`${this.name}: ${size}`);
-      if (incomplete) await sleep(1000);
+
+      // If incomplete, probably getting rate-limited
+      if (incomplete) await sleep(5000);
     }
 
     this.replenishing = false;

--- a/server/src/supply/fee_accounts.ts
+++ b/server/src/supply/fee_accounts.ts
@@ -3,10 +3,10 @@ import {
   Connection,
   FeeCalculator,
   SystemProgram,
-  sendAndConfirmTransaction,
 } from "@solana/web3.js";
 import AccountSupply, { TX_PER_ACCOUNT } from "./accounts";
 import Faucet from "../faucet";
+import { confirmTransaction } from "../utils";
 
 // Provides pre-funded accounts for break game clients
 export default class FeeAccountSupply {
@@ -25,16 +25,16 @@ export default class FeeAccountSupply {
       faucet.feeAccount,
       async (fromAccount: Account) => {
         const account = new Account();
-        await sendAndConfirmTransaction(
-          connection,
+        const signature = await connection.sendTransaction(
           SystemProgram.transfer({
             fromPubkey: fromAccount.publicKey,
             toPubkey: account.publicKey,
             lamports: fundAmount,
           }),
           [fromAccount],
-          { confirmations: 1, skipPreflight: true }
+          { skipPreflight: true }
         );
+        await confirmTransaction(connection, signature);
         return account;
       }
     );

--- a/server/src/supply/program_accounts.ts
+++ b/server/src/supply/program_accounts.ts
@@ -4,10 +4,10 @@ import {
   FeeCalculator,
   PublicKey,
   SystemProgram,
-  sendAndConfirmTransaction,
 } from "@solana/web3.js";
 import AccountSupply, { TX_PER_ACCOUNT } from "./accounts";
 import Faucet from "../faucet";
+import { confirmTransaction } from "../utils";
 
 const TX_PER_BYTE = 8;
 
@@ -28,8 +28,7 @@ export default class ProgramAccountSupply {
       faucet.feeAccount,
       async (fromAccount: Account) => {
         const programDataAccount = new Account();
-        await sendAndConfirmTransaction(
-          connection,
+        const signature = await connection.sendTransaction(
           SystemProgram.createAccount({
             fromPubkey: fromAccount.publicKey,
             newAccountPubkey: programDataAccount.publicKey,
@@ -38,8 +37,9 @@ export default class ProgramAccountSupply {
             programId,
           }),
           [fromAccount, programDataAccount],
-          { confirmations: 1, skipPreflight: true }
+          { skipPreflight: true }
         );
+        await confirmTransaction(connection, signature);
         return programDataAccount;
       }
     );


### PR DESCRIPTION
#### Problem
The break server gets rate limited pretty easily when polling for signature status

#### Changes
- Use pubsub api to confirm signatures instead
- Add env var to adjust account replenish rate