### PR TITLE
Improve server account supply replenishing

### DIFF
--- a/server/src/api.ts
+++ b/server/src/api.ts
@@ -35,8 +35,8 @@ export default class ApiServer {
     const tpuProxy = await TpuProxy.create(connection);
     WebSocketServer.start(httpServer, tpuProxy);
 
+    const faucet = await Faucet.init(connection);
     const feeCalculator = await ApiServer.getFeeCalculator(connection);
-    const faucet = await Faucet.init(connection, feeCalculator);
     const programId = await ProgramLoader.load(
       connection,
       faucet,

--- a/server/src/supply/accounts.ts
+++ b/server/src/supply/accounts.ts
@@ -97,7 +97,9 @@ export default class AccountSupply {
     this.replenishing = true;
 
     let size = await this.size();
-    while (size < SUPPLY_SIZE) {
+    let retriesRemaining = 3;
+    while (size < SUPPLY_SIZE && retriesRemaining > 0) {
+      retriesRemaining--;
       const batchSize = Math.min(SUPPLY_SIZE - size, BATCH_SIZE);
       const batch = await this.createBatch(this.faucetAccount, batchSize);
 

--- a/server/src/supply/fee_accounts.ts
+++ b/server/src/supply/fee_accounts.ts
@@ -4,10 +4,10 @@ import {
   FeeCalculator,
   Transaction,
   SystemProgram,
+  sendAndConfirmTransaction,
 } from "@solana/web3.js";
 import AccountSupply, { TX_PER_ACCOUNT } from "./accounts";
 import Faucet from "../faucet";
-import { confirmTransaction } from "../utils";
 
 // Provides pre-funded accounts for break game clients
 export default class FeeAccountSupply {
@@ -26,7 +26,8 @@ export default class FeeAccountSupply {
       faucet.feeAccount,
       async (fromAccount: Account) => {
         const account = new Account();
-        const signature = await connection.sendTransaction(
+        await sendAndConfirmTransaction(
+          connection,
           new Transaction().add(
             SystemProgram.transfer({
               fromPubkey: fromAccount.publicKey,
@@ -35,9 +36,8 @@ export default class FeeAccountSupply {
             })
           ),
           [fromAccount],
-          { skipPreflight: true }
+          { commitment: "singleGossip", preflightCommitment: "singleGossip" }
         );
-        await confirmTransaction(connection, signature);
         return account;
       }
     );

--- a/server/src/supply/program_accounts.ts
+++ b/server/src/supply/program_accounts.ts
@@ -3,12 +3,12 @@ import {
   Connection,
   FeeCalculator,
   PublicKey,
+  sendAndConfirmTransaction,
   SystemProgram,
   Transaction,
 } from "@solana/web3.js";
 import AccountSupply, { TX_PER_ACCOUNT } from "./accounts";
 import Faucet from "../faucet";
-import { confirmTransaction } from "../utils";
 
 const TX_PER_BYTE = 8;
 
@@ -29,7 +29,8 @@ export default class ProgramAccountSupply {
       faucet.feeAccount,
       async (fromAccount: Account) => {
         const programDataAccount = new Account();
-        const signature = await connection.sendTransaction(
+        await sendAndConfirmTransaction(
+          connection,
           new Transaction().add(
             SystemProgram.createAccount({
               fromPubkey: fromAccount.publicKey,
@@ -40,9 +41,8 @@ export default class ProgramAccountSupply {
             })
           ),
           [fromAccount, programDataAccount],
-          { skipPreflight: true }
+          { commitment: "singleGossip", preflightCommitment: "singleGossip" }
         );
-        await confirmTransaction(connection, signature);
         return programDataAccount;
       }
     );

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,5 +1,3 @@
-import { TransactionSignature, Connection } from "@solana/web3.js";
-
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -22,29 +20,4 @@ export async function endlessRetry<T>(
       await sleep(1000);
     }
   }
-}
-
-export async function confirmTransaction(
-  connection: Connection,
-  signature: TransactionSignature
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    let timeout: NodeJS.Timeout | undefined = undefined;
-    const id = connection.onSignature(
-      signature,
-      (result) => {
-        if (timeout) clearTimeout(timeout);
-        if (result.err) {
-          reject("failed");
-        } else {
-          resolve();
-        }
-      },
-      "singleGossip"
-    );
-    timeout = setTimeout(() => {
-      connection.removeSignatureListener(id);
-      reject("timeout");
-    }, 10000);
-  });
 }


### PR DESCRIPTION
#### Problems
- Add max retries to account replenishing
- When skipping preflight, it was possible to send bad transactions and get hit by transaction fees
- Fix balance check logging
- Improve payment reliability by using `singleGossip` over `recent`