### PR TITLE
Fix the TxModal Finalization status

### DIFF
--- a/client/src/components/TxModal.tsx
+++ b/client/src/components/TxModal.tsx
@@ -127,16 +127,14 @@ export function TransactionDetails({
 
   function displayFinalized() {
     if (transaction.status === "success") {
-      if (transaction.pending) {
-        return (
-          <div>
-            <span className="spinner-grow spinner-grow-sm mr-2"></span>
-            Pending
-          </div>
-        );
-      } else {
-        return <span className="text-success">Finalized</span>;
-      }
+      return <span className="text-success">Finalized</span>;
+    } else if (transaction.status === "pending") {
+      return (
+        <div>
+          <span className="spinner-grow spinner-grow-sm mr-2"></span>
+          Pending
+        </div>
+      );
     } else {
       return "N/A";
     }


### PR DESCRIPTION
Fix the TxModal Finalization status. The current code shows 'N/A' when the status is 'pending' and when the status is 'success', the transaction object still has a pending object so the current check is always in a pending status. So I changed the code to just check the status of the transaction.