### PR TITLE
Update Readme with Instructions for Handling Missing Docker Image Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ npm run localnet:up
 npm run start:dev
 ```
 
+_Note: It may be necessary to pull the required docker image if `npm run localnet:up` fails with the message `Unable to find image 'solanalabs/solana:edge' locally`. Run the below command if that is the case, then try again._ 
+```
+# Pull the docker image
+docker pull solanalabs/solana:edge
+```
+
 #### Configuration
 
 By default, the Break server will connect to a local node for RPC and will use a faucet to fund game play. To configure this behavior, set the following environment variables when running the server:


### PR DESCRIPTION
The docker image for solanalabs/solana:edge isn't pulled by default, which causes the `npm run localnet:up` command to fail.
This can be solved by pulling the docker image. I haven't found the relevant script to change to include the docker command by default, perhaps that would be a great next step.