### PR TITLE
Fixed incorrect badge image source URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Break Solana Game [![Build Status](https://github.com/solana-labs/break/actions/workflows/node-ci.yml/badge.svg?branch=main)](https://github.com/solana-labs/break/actions/workflows/node-ci.yml?query=branch%3Amain)
+## Break Solana Game [![Build Status](https://github.com/solana-labs/break/actions/workflows/break_action.yml/badge.svg?branch=main)](https://github.com/solana-labs/break/actions/workflows/break_action.yml/badge.svg?branch=main)
 
 ### How it works
 


### PR DESCRIPTION
This is quite straight forward change:

An image source URL change fixes the badge displayed on the README.